### PR TITLE
Delete setlocal textwidth

### DIFF
--- a/plugin/longlines.vim
+++ b/plugin/longlines.vim
@@ -83,7 +83,6 @@ function! s:longlines_on() abort
   " These options aren't useful when the longline mode is on.
   setlocal colorcolumn=
   setlocal linebreak
-  setlocal textwidth=0
   setlocal wrap
   setlocal wrapmargin=0
 


### PR DESCRIPTION
As we already have `setlocal formatoption +=l` to prevent longline break, it is not necessary to `setlocal textwidth=0` as it doesn't matter what value `tw` is.

Even though preset `textwidth` is not necessary, `setlocal tw=0` here may create conflict with setting up a default value of `textwidth` in `.vimrc`, especially when when load `LongLines` with `autocmd`. For example, people may have a function to toggle `ColorColumn` at `+1`, which is not possible without a `textwidth` value.