### PR TITLE
Delete `setlocal textwidth` and `setlocal colorcolumn`

### DIFF
--- a/plugin/longlines.vim
+++ b/plugin/longlines.vim
@@ -83,7 +83,6 @@ function! s:longlines_on() abort
   " These options aren't useful when the longline mode is on.
   setlocal colorcolumn=
   setlocal linebreak
-  setlocal textwidth=0
   setlocal wrap
   setlocal wrapmargin=0
 

--- a/plugin/longlines.vim
+++ b/plugin/longlines.vim
@@ -9,7 +9,7 @@ endif
 let g:longlines_loaded = 1
 
 " List of options that longlines will change.
-let s:optkeys = ['colorcolumn', 'formatoptions', 'linebreak', 'textwidth', 'wrap', 'wrapmargin']
+let s:optkeys = ['formatoptions', 'linebreak', 'wrap', 'wrapmargin']
 
 augroup longlines
   autocmd!

--- a/plugin/longlines.vim
+++ b/plugin/longlines.vim
@@ -81,7 +81,6 @@ function! s:longlines_on() abort
   setlocal formatoptions+=l
 
   " These options aren't useful when the longline mode is on.
-  setlocal colorcolumn=
   setlocal linebreak
   setlocal wrap
   setlocal wrapmargin=0


### PR DESCRIPTION
As we already have `setlocal formatoption +=l` to prevent longline break, it is not necessary to `setlocal textwidth=0` as it doesn't matter what value `tw` is.

Even though preset `textwidth` is not necessary, `setlocal tw=0` here may create conflict with setting up a default value of `textwidth` in` .vimrc`, especially when when we autoload LongLines with `autocmd`. For example, people may have a function to toggle `ColorColumn` at `+1`, which is not possible without a `textwidth` value.

A similar rationale is also applied for deleting `setlocal colorcolum=`.